### PR TITLE
Set the default scale to 1

### DIFF
--- a/fractal-art.js
+++ b/fractal-art.js
@@ -30,7 +30,7 @@ var points = {
 // Super Detailed Style
 var style = {
 	level: 19,
-	scale: 2,
+	scale: 1,
 	background: "transparent",
 	alpha: 1,
 	color: {


### PR DESCRIPTION
I accidentally made the default scale set to 2. This error was carried forward from the code on JSbin.